### PR TITLE
Macro simplification & bug fix

### DIFF
--- a/alphabet-soup-macros/src/main/scala/io/typechecked/alphabetsoup/macros/Atomic.scala
+++ b/alphabet-soup-macros/src/main/scala/io/typechecked/alphabetsoup/macros/Atomic.scala
@@ -14,7 +14,6 @@ object AtomicMacro {
 
   def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
-    import Flag._
 
     def mkAtomImplicit(className: TypeName) = {
         q"""implicit val ${TermName(className.toTermName.toString + "atom")}: io.typechecked.alphabetsoup.Atom[$className] = io.typechecked.alphabetsoup.Atom[$className]"""

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomMacroSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomMacroSpec.scala
@@ -96,7 +96,7 @@ class AtomMacroSpec extends FlatSpec with Matchers {
   }
   it should "create an implicit Atom for a protected sealed abstract protected Class" in {
 
-    implicitly[Atom[PrivateFoo]]
+    implicitly[Atom[ProtectedFoo]]
   }
   it should "create an implicit Atom for a Trait" in {
     @Atomic trait Foo
@@ -144,10 +144,16 @@ class AtomMacroSpec extends FlatSpec with Matchers {
 
     implicitly[Atom[Foo]]
   }
+  it should "create an implicit Atom for private package classes" in {
+    implicitly[Atom[PrivateFoo]]
+  }
   it should "not compile for objects" in {
+
    illTyped("@Atomic object Foo",".*Invalid: Can not annotate structure with @Atomic.*")
+
   }
 }
 
-@Atomic protected sealed abstract class PrivateFoo(implicit impl: DummyImplicit)
+@Atomic protected sealed abstract class ProtectedFoo(implicit impl: DummyImplicit)
 
+@Atomic private[alphabetsoup] class PrivateFoo

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomMacroSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomMacroSpec.scala
@@ -139,6 +139,14 @@ class AtomMacroSpec extends FlatSpec with Matchers {
       implicitly[Atom[A]]
     }
   }
+  it should "create an implicit Atom for a class with a private constructor" in {
+    @Atomic class Foo private(bar:Int, val baz:String)
+
+    implicitly[Atom[Foo]]
+  }
+  it should "not compile for objects" in {
+   illTyped("@Atomic object Foo",".*Invalid: Can not annotate structure with @Atomic.*")
+  }
 }
 
 @Atomic protected sealed abstract class PrivateFoo(implicit impl: DummyImplicit)


### PR DESCRIPTION
Simplify macro creation and fix bug which prevented following from compiling

```scala
class Foo private(bar:Int)
```

