### PR TITLE
Mixer inject

### DIFF
--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Mixer.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Mixer.scala
@@ -15,6 +15,7 @@ trait Mixer[A, B] {
 
 object Mixer {
 
+  // TODO: This second implicit's functionality should be built up inside, rather than created here
   def apply[A, B](implicit m: MixerImpl[A, B], r: MixerImpl[(B, A), A]): Mixer[A, B] = fromMixerImpl(m, r)
 
   implicit def materialise[A, B](implicit m: MixerImpl[A, B], r: MixerImpl[(B, A), A]): Mixer[A, B] = fromMixerImpl(m, r)

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Mixer.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Mixer.scala
@@ -10,7 +10,7 @@ import shapeless.Lazy
 // This is the version code should use
 trait Mixer[A, B] {
   def mix(a: A): B
-  def replace(b: B, a: A): A
+  def inject(b: B, a: A): A
 }
 
 object Mixer {
@@ -39,7 +39,7 @@ object Mixer {
             m.mix(a :: defaults :: HNil)
           }
 
-          def replace(b: To, a: From): From = r.mix(b -> a)
+          def inject(b: To, a: From): From = r.mix(b -> a)
         }
 
     }
@@ -49,7 +49,7 @@ object Mixer {
   private def fromMixerImpl[A, B](m: MixerImpl[A, B], r: MixerImpl[(B, A), A]): Mixer[A, B] = new Mixer[A, B] {
     def mix(a: A): B = m.mix(a)
 
-    def replace(b: B, a: A): A = r.mix(b -> a)
+    def inject(b: B, a: A): A = r.mix(b -> a)
   }
 }
 

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerReplaceSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerReplaceSpec.scala
@@ -1,0 +1,69 @@
+package io.typechecked.alphabetsoup
+
+import io.typechecked.alphabetsoup.macros.Atomic
+import org.scalatest.{FlatSpec, Matchers}
+import shapeless.test.illTyped
+
+class MixerReplaceSpec extends FlatSpec with Matchers {
+
+  "Mixer.injectq" should "work for simple types" in {
+    case class Source(a: Int)
+    case class Target(b: Int)
+
+    Mixer[Source, Target].injectq(Target(7), Source(1)) shouldBe Source(7)
+  }
+  it should "work for nested types" in {
+    @Atomic case class Inner(i: Int)
+    case class Source(i: Inner)
+    case class Target(i: Inner)
+
+    Mixer[Source, Target].injectq(Target(Inner(7)), Source(Inner(12))) shouldBe Source(Inner(7))
+  }
+  it should "work when source is a complex nested structure" in {
+    case class MostInner(s: String)
+    case class Inner1(a: MostInner)
+    case class Inner2(a: MostInner)
+    case class Source(a: Inner1, b: Inner2)
+
+    case class Target(s: MostInner)
+
+    val source = Source(Inner1(MostInner("LOOK AT ME!")), Inner2(MostInner("I'M OVER HERE")))
+
+    val target = Target(MostInner("Nah"))
+
+    Mixer[Source, Target].injectq(target, source) shouldBe Source(Inner1(MostInner("Nah")), Inner2(MostInner("Nah")))
+  }
+  it should "work for complex structures" in {
+    case class A(i: Int, b: Boolean)
+    case class B(i: String)
+    case class Source(i: Int, s: String, as: List[A], bs: List[B])
+
+    case class BS(bs: List[B])
+    case class Target(i: Int, bs: BS, as: List[(Boolean, Int)])
+
+    val a1 = A(1, true)
+    val a2 = A(2, false)
+    val a3 = A(3, true)
+
+    val b1 = B("ten")
+    val b2 = B("twenty")
+
+    val source = Source(17, "DANGER", List(A(0, false), A(0, true), A(0, false)), List(B("NOOO"), B("NOT MEEEEE")))
+    val target = Target(7, BS(List(b1, b2)), List(true -> 1, false -> 2, true -> 3))
+
+    Mixer[Source, Target].injectq(target, source) shouldBe Source(7, "DANGER", List(a1, a2, a3), List(b1, b2))
+  }
+  it should "work when values are the same" in {
+    case class Source(a: Int)
+    case class Target(b: Int)
+
+    Mixer[Source, Target].injectq(Target(1), Source(1)) shouldBe Source(1)
+  }
+  it should "not work if target is not wholly contained within source" in {
+    case class Source(a: Int)
+    case class Target(b: Int, c: String)
+
+    illTyped("Mixer[Source, Target].injectq(Target(1), Source(1)) shouldBe Source(1)")
+  }
+
+}

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerReplaceSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerReplaceSpec.scala
@@ -6,18 +6,18 @@ import shapeless.test.illTyped
 
 class MixerReplaceSpec extends FlatSpec with Matchers {
 
-  "Mixer.injectq" should "work for simple types" in {
+  "Mixer.inject" should "work for simple types" in {
     case class Source(a: Int)
     case class Target(b: Int)
 
-    Mixer[Source, Target].injectq(Target(7), Source(1)) shouldBe Source(7)
+    Mixer[Source, Target].inject(Target(7), Source(1)) shouldBe Source(7)
   }
   it should "work for nested types" in {
     @Atomic case class Inner(i: Int)
     case class Source(i: Inner)
     case class Target(i: Inner)
 
-    Mixer[Source, Target].injectq(Target(Inner(7)), Source(Inner(12))) shouldBe Source(Inner(7))
+    Mixer[Source, Target].inject(Target(Inner(7)), Source(Inner(12))) shouldBe Source(Inner(7))
   }
   it should "work when source is a complex nested structure" in {
     case class MostInner(s: String)
@@ -31,7 +31,7 @@ class MixerReplaceSpec extends FlatSpec with Matchers {
 
     val target = Target(MostInner("Nah"))
 
-    Mixer[Source, Target].injectq(target, source) shouldBe Source(Inner1(MostInner("Nah")), Inner2(MostInner("Nah")))
+    Mixer[Source, Target].inject(target, source) shouldBe Source(Inner1(MostInner("Nah")), Inner2(MostInner("Nah")))
   }
   it should "work for complex structures" in {
     case class A(i: Int, b: Boolean)
@@ -51,19 +51,19 @@ class MixerReplaceSpec extends FlatSpec with Matchers {
     val source = Source(17, "DANGER", List(A(0, false), A(0, true), A(0, false)), List(B("NOOO"), B("NOT MEEEEE")))
     val target = Target(7, BS(List(b1, b2)), List(true -> 1, false -> 2, true -> 3))
 
-    Mixer[Source, Target].injectq(target, source) shouldBe Source(7, "DANGER", List(a1, a2, a3), List(b1, b2))
+    Mixer[Source, Target].inject(target, source) shouldBe Source(7, "DANGER", List(a1, a2, a3), List(b1, b2))
   }
   it should "work when values are the same" in {
     case class Source(a: Int)
     case class Target(b: Int)
 
-    Mixer[Source, Target].injectq(Target(1), Source(1)) shouldBe Source(1)
+    Mixer[Source, Target].inject(Target(1), Source(1)) shouldBe Source(1)
   }
   it should "not work if target is not wholly contained within source" in {
     case class Source(a: Int)
     case class Target(b: Int, c: String)
 
-    illTyped("Mixer[Source, Target].injectq(Target(1), Source(1)) shouldBe Source(1)")
+    illTyped("Mixer[Source, Target].inject(Target(1), Source(1)) shouldBe Source(1)")
   }
 
 }

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
@@ -272,7 +272,7 @@ class MixerSpec extends FlatSpec with Matchers {
     implicit val mixer: Mixer[A, (Boolean, Int)] = new Mixer[A, (Boolean, Int)] {
       def mix(a: A): (Boolean, Int) = a.b -> (a.i + 100)
 
-      def replace(b: (Boolean, Int), a: A): A = a
+      def inject(b: (Boolean, Int), a: A): A = a
     }
 
     val source = Source(List(A(1, true), A(2, false), A(3, true)))

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
@@ -271,6 +271,8 @@ class MixerSpec extends FlatSpec with Matchers {
     // behaviour with our own
     implicit val mixer: Mixer[A, (Boolean, Int)] = new Mixer[A, (Boolean, Int)] {
       def mix(a: A): (Boolean, Int) = a.b -> (a.i + 100)
+
+      def replace(b: (Boolean, Int), a: A): A = a
     }
 
     val source = Source(List(A(1, true), A(2, false), A(3, true)))


### PR DESCRIPTION
`Mixer` now provides an additional function `inject`.

This allows types to be _injected_ from targets into the source.

For example:
```scala
@Atomic case class Inner(i: Int)
case class Source(i: Inner)
case class Target(i: Inner)

Mixer[Source, Target].inject(Target(Inner(7)), Source(Inner(12))) shouldBe Source(Inner(7))
```
