### PR TITLE
Atom replacing functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+
+*.sublime-workspace
+*.sublime-project
+
+.DS_Store

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/AtomSelector.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/AtomSelector.scala
@@ -13,10 +13,10 @@ object AtomSelector {
   def apply[L, U](implicit atomSelector: AtomSelector[L, U]): AtomSelector[L, U] = atomSelector
 
   implicit def atomiseThenDelegate[L, LOut, U](
-    implicit dg: Atomiser.Aux[L, LOut],
+    implicit atomiser: Atomiser.Aux[L, LOut],
     s: SelectOrDefault[LOut, U]
   ): AtomSelector[L, U] = new AtomSelector[L, U] {
-    def apply(t: L): U = s(dg.to(t))
+    def apply(t: L): U = s(atomiser.to(t))
   }
 
 }

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/AtomSelector.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/AtomSelector.scala
@@ -6,6 +6,7 @@ import shapeless.{::, HList}
 // TODO rename, now also handles molecules
 trait AtomSelector[L, U] {
   def apply(l: L): U
+  def replace(u: U, l: L): L
 }
 
 object AtomSelector {
@@ -17,6 +18,7 @@ object AtomSelector {
     s: SelectOrDefault[LOut, U]
   ): AtomSelector[L, U] = new AtomSelector[L, U] {
     def apply(t: L): U = s(atomiser.to(t))
+    def replace(u: U, l: L): L = atomiser.from(s.replace(u, atomiser.to(l)))
   }
 
 }

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Mixer.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Mixer.scala
@@ -7,7 +7,7 @@ import shapeless.HList
 import shapeless.HNil
 import shapeless.Lazy
 
-// This is the version code should use
+// This is the version application code should use
 trait Mixer[A, B] {
   def mix(a: A): B
   def inject(b: B, a: A): A
@@ -15,10 +15,9 @@ trait Mixer[A, B] {
 
 object Mixer {
 
-  // TODO: This second implicit's functionality should be built up inside, rather than created here
-  def apply[A, B](implicit m: MixerImpl[A, B], r: MixerImpl[(B, A), A]): Mixer[A, B] = fromMixerImpl(m, r)
+  def apply[A, B](implicit m: MixerImpl[A, B]): Mixer[A, B] = fromMixerImpl(m)
 
-  implicit def materialise[A, B](implicit m: MixerImpl[A, B], r: MixerImpl[(B, A), A]): Mixer[A, B] = fromMixerImpl(m, r)
+  implicit def materialise[A, B](implicit m: MixerImpl[A, B]): Mixer[A, B] = fromMixerImpl(m)
 
   def from[From]: MixerBuilder[From] = new MixerBuilder[From] {}
 
@@ -36,10 +35,7 @@ object Mixer {
 
       def build(implicit m: MixerImpl[From :: Defaults :: HNil, To], r: MixerImpl[(To, From), From]): Mixer[From, To] =
         new Mixer[From, To] {
-          def mix(a: From): To = {
-            m.mix(a :: defaults :: HNil)
-          }
-
+          def mix(a: From): To = m.mix(a :: defaults :: HNil)
           def inject(b: To, a: From): From = r.mix(b -> a)
         }
 
@@ -47,17 +43,25 @@ object Mixer {
 
   }
 
-  private def fromMixerImpl[A, B](m: MixerImpl[A, B], r: MixerImpl[(B, A), A]): Mixer[A, B] = new Mixer[A, B] {
-    def mix(a: A): B = m.mix(a)
-
-    def inject(b: B, a: A): A = r.mix(b -> a)
-  }
+  private def fromMixerImpl[A, B](m: MixerImpl[A, B]): Mixer[A, B] =
+    new Mixer[A, B] {
+      def mix(a: A): B = m.mix(a)
+      def inject(b: B, a: A): A = m.inject(b, a)
+    }
 }
 
-// This exists to separate the concerns of implicit searches and Mixer building and defaults, which
-// is presented in object Mixer. Code should not use this.
+/**
+ * Mixes A into B, atomising them both as a first step
+ *
+ * Allows you to inject an instance of B into an instance of A, replacing all values in A whose types
+ * have a corresponding value in B
+ *
+ * MixerImplFromAtomised[A, B].inject(b, a) is the same as MixerImplFromAtomised[(B, A), A].mix(b -> a)
+ * but more efficient due to reusing the same internal structures
+ */
 trait MixerImpl[A, B] {
   def mix(a: A): B
+  def inject(b: B, a: A): A
 }
 
 object MixerImpl {
@@ -66,6 +70,7 @@ object MixerImpl {
 
   implicit def mixerImplEquality[A]: MixerImpl[A, A] = new MixerImpl[A, A] {
     def mix(a: A): A = a
+    def inject(b: A, a: A): A = b
   }
 
   implicit def atomiseThenImpl[A, AOut, B, BOut <: HList](
@@ -75,6 +80,12 @@ object MixerImpl {
     m: Lazy[MixerImplFromAtomised[AOut, BOut]]
   ): MixerImpl[A, B] = new MixerImpl[A, B] {
     def mix(a: A): B = atomiserB.from(m.value.mix(atomiserA.to(a)))
+    def inject(b: B, a: A): A = {
+      val bAtoms = atomiserB.to(b)
+      val aAtoms = atomiserA.to(a)
+      val injected = m.value.inject(bAtoms, aAtoms)
+      atomiserA.from(injected)
+    }
   }
 
   implicit def bIsAtomRecurse[A, B](
@@ -82,6 +93,7 @@ object MixerImpl {
     s: AtomSelector[A, B]
   ): MixerImpl[A, B] = new MixerImpl[A, B] {
     def mix(a: A): B = s(a)
+    def inject(b: B, a: A): A = s.replace(b, a)
   }
 
   implicit def bIsMoleculeRecurse[A, M[_], B](
@@ -89,13 +101,23 @@ object MixerImpl {
     s: AtomSelector[A, M[B]]
   ): MixerImpl[A, M[B]] = new MixerImpl[A, M[B]] {
     def mix(a: A): M[B] = s(a)
+    def inject(b: M[B], a: A): A = s.replace(b, a)
   }
 
 }
 
-// A mixer that assumes the both sides are atomised
+/**
+ * Mixes A into B, assuming both A and B have been atomised
+ *
+ * Allows you to inject an instance of B into an instance of A, replacing all values in A whose types
+ * have a corresponding value in B
+ *
+ * MixerImplFromAtomised[A, B].inject(b, a) is the same as MixerImplFromAtomised[(B, A), A].mix(b -> a)
+ * but more efficient due to reusing the same internal structures
+ */
 trait MixerImplFromAtomised[A, B] {
   def mix(a: A): B
+  def inject(b: B, a: A): A
 }
 
 object MixerImplFromAtomised extends LowPriorityMFAImplicits1 {
@@ -105,6 +127,7 @@ object MixerImplFromAtomised extends LowPriorityMFAImplicits1 {
   // Anything can satisfy HNil
   implicit def hnilCase[A]: MixerImplFromAtomised[A, HNil] = new MixerImplFromAtomised[A, HNil] {
     def mix(a: A): HNil = HNil
+    def inject(b: HNil, a: A): A = a
   }
 
   implicit def bHeadIsAtomRecurse[A, BH, BT <: HList](
@@ -113,6 +136,10 @@ object MixerImplFromAtomised extends LowPriorityMFAImplicits1 {
     m2: MixerImplFromAtomised[A, BT]
   ): MixerImplFromAtomised[A, BH :: BT] = new MixerImplFromAtomised[A, BH :: BT] {
     def mix(a: A): BH :: BT = s(a) :: m2.mix(a)
+    def inject(b: BH :: BT, a: A): A = {
+      val tailInjected = m2.inject(b.tail, a)
+      s.replace(b.head, tailInjected)
+    }
   }
 
   implicit def bHeadIsMoleculeRecurse[A, M[_], BH, BT <: HList](
@@ -121,6 +148,10 @@ object MixerImplFromAtomised extends LowPriorityMFAImplicits1 {
     m2: MixerImplFromAtomised[A, BT]
   ): MixerImplFromAtomised[A, M[BH] :: BT] = new MixerImplFromAtomised[A, M[BH] :: BT] {
     def mix(a: A): M[BH] :: BT = s(a) :: m2.mix(a)
+    def inject(b: M[BH] :: BT, a: A): A = {
+      val tailInjected = m2.inject(b.tail, a)
+      s.replace(b.head, tailInjected)
+    }
   }
 
 }
@@ -132,6 +163,10 @@ trait LowPriorityMFAImplicits1 {
     m2: MixerImplFromAtomised[A, BT]
   ): MixerImplFromAtomised[A, (BHH :: BHT) :: BT] = new MixerImplFromAtomised[A, (BHH :: BHT) :: BT] {
     def mix(a: A): (BHH :: BHT) :: BT = m1.value.mix(a) :: m2.mix(a)
+    def inject(b: (BHH :: BHT) :: BT, a: A): A = {
+      val tailInjected = m2.inject(b.tail, a)
+      m1.value.inject(b.head, tailInjected)
+    }
   }
 
 }

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/SelectFromAtomised.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/SelectFromAtomised.scala
@@ -2,16 +2,45 @@ package io.typechecked
 package alphabetsoup
 
 import shapeless.Lazy
-import shapeless.{::, HList}
+import shapeless.{::, HList, =:!=}
 
 /**
- * A trait that extracts a value U (atom or molecule) from a type L, provided the type L
+ * A trait that extracts or replaces a value U (atom or molecule) from a type L, provided the type L
  * has been atomised first.
  *
  * If no such value exists, it does not compile
+ *
+ * ## Molecules
+ *
+ * ### Selecting
+ *
+ * You can select an M[B] from a structure as long as you can select an M[A], where a Mixer[B, A] exists.
+ *
+ * The M[A] is simply mapped over with the mixer. In the case where B = A, the same functionality occurs without
+ * the mixer step
+ *
+ * ### Replacing
+ *
+ * If you replace a List[A] with a List[A], the entire structure will be replaced by the new list.
+ * Ie, the length will be the length of the new list.
+ *
+ * This is DIFFERENT behaviour to the selection case, where the original structure is preserved. Molecules act as
+ * atoms for replacing, as you would expect if you replaced a list with another list; you would expect the
+ * length to be the length of the new list.
+ *
+ * You are unable to replace an M[B] with an M[A] if B != A, even if there is a Mixer[B, A] present. We simply ignore
+ * the replacement request.
+ *
+ * This is equivalent to the bahviour you would expect of Mixer[(B, A), A], where a Miaxer[A, B] exists
  */
 trait SelectFromAtomised[L, U] {
+
+  /** Select the first instance of U found within L */
   def apply(l: L): U
+
+  /** Replace the first instance of U found within l with u */
+  def replace(u: U, l: L): L
+
 }
 
 // TODO: Atom/Molecule paths could be unified or split more sensibly
@@ -22,26 +51,39 @@ object SelectFromAtomised {
   implicit def headAtomSelect[H: Atom, T <: HList]: SelectFromAtomised[H :: T, H] =
     new SelectFromAtomised[H :: T, H] {
       def apply(l: H :: T): H = l.head
+      def replace(u: H, l: H :: T): H :: T = u :: l.tail
     }
 
   implicit def recurse[H, T <: HList, U: Atom](implicit st: SelectFromAtomised[T, U]): SelectFromAtomised[H :: T, U] =
     new SelectFromAtomised[H :: T, U] {
-      def apply(l: H :: T) = st(l.tail)
+      def apply(l: H :: T): U = st(l.tail)
+      def replace(u: U, l: H :: T): H :: T = l.head :: st.replace(u, l.tail)
     }
 
   implicit def recurseNested[H <: HList, T <: HList, U: Atom](
     implicit st: Lazy[SelectFromAtomised[H, U]]
   ): SelectFromAtomised[H :: T, U] =
     new SelectFromAtomised[H :: T, U] {
-      def apply(l: H :: T) = st.value(l.head)
+      def apply(l: H :: T): U = st.value(l.head)
+      def replace(u: U, l: H :: T): H :: T = st.value.replace(u, l.head) :: l.tail
     }
 
   implicit def fuzzyHeadSelectMolecule[M[_], A, T <: HList, B](
     implicit molecule: Molecule[M, B],
+    ev: A =:!= B,
     mixer: Lazy[Mixer[A, B]]
   ): SelectFromAtomised[M[A] :: T, M[B]] =
     new SelectFromAtomised[M[A] :: T, M[B]] {
       def apply(t: M[A] :: T): M[B] = molecule.functor.map(t.head)(mixer.value.mix)
+      def replace(u: M[B], l: M[A] :: T): M[A] :: T = l
+    }
+
+  implicit def preciseHeadSelectMolecule[M[_], A, T <: HList](
+    implicit molecule: Molecule[M, A]
+  ): SelectFromAtomised[M[A] :: T, M[A]] =
+    new SelectFromAtomised[M[A] :: T, M[A]] {
+      def apply(t: M[A] :: T): M[A] = t.head
+      def replace(u: M[A], l: M[A] :: T): M[A] :: T = u :: l.tail
     }
 
   implicit def recurseTailMolecule[H, T <: HList, M[_], U](
@@ -49,7 +91,8 @@ object SelectFromAtomised {
     st: SelectFromAtomised[T, M[U]]
   ): SelectFromAtomised[H :: T, M[U]] =
     new SelectFromAtomised[H :: T, M[U]] {
-      def apply(l: H :: T) = st(l.tail)
+      def apply(l: H :: T): M[U] = st(l.tail)
+      def replace(u: M[U], l: H :: T): H :: T = l.head :: st.replace(u, l.tail)
     }
 
   implicit def recurseHeadMolecule[H <: HList, T <: HList, U, M[_]](
@@ -57,7 +100,8 @@ object SelectFromAtomised {
     st: Lazy[SelectFromAtomised[H, M[U]]]
   ): SelectFromAtomised[H :: T, M[U]] =
     new SelectFromAtomised[H :: T, M[U]] {
-      def apply(l: H :: T) = st.value(l.head)
+      def apply(l: H :: T): M[U] = st.value(l.head)
+      def replace(u: M[U], l: H :: T): H :: T = st.value.replace(u, l.head) :: l.tail
     }
 
 }

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/SelectOrDefault.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/SelectOrDefault.scala
@@ -6,17 +6,27 @@ package alphabetsoup
  * of type U
  *
  * This assumes L is atomised.
+ *
+ * ### Replace behaviour
+ *
+ * If we can select U from L, replace acts as it does for SelectFromAtomised
+ *
+ * If we can not select U from L and rely on an implicit default, we replace nothing and return our L unchanged
  */
 trait SelectOrDefault[L, U] {
   def apply(l: L): U
+  def replace(u: U, l: L): L
 }
 
 object SelectOrDefault extends LowPrioritySelectOrDefault {
 
+  def apply[L, U](implicit s: SelectOrDefault[L, U]): SelectOrDefault[L, U] = s
+
   implicit def trySelectFromAtomised[L, U](implicit selector: SelectFromAtomised[L, U]): SelectOrDefault[L, U] =
     new SelectOrDefault[L, U] {
       def apply(l: L): U = selector(l)
-  }
+      def replace(u: U, l: L): L = selector.replace(u, l)
+    }
 
 }
 
@@ -24,5 +34,6 @@ trait LowPrioritySelectOrDefault {
   implicit def tryDefaultSelect[L, U](implicit defaultAS: Atom.DefaultAtom[U]): SelectOrDefault[L, U] =
     new SelectOrDefault[L, U] {
       def apply(l: L): U = defaultAS.default
+      def replace(u: U, l: L): L = l
     }
 }

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomSelectorSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomSelectorSpec.scala
@@ -10,8 +10,7 @@ class AtomSelectorSpec extends FlatSpec with Matchers {
   case class Pair(i: Int, s: String)
   case class T(p: Pair, b: Boolean)
 
-  "AtomSelector" should "not work on atoms" in {
-
+  "AtomSelector" should "not work on atomic structures" in {
     illTyped("AtomSelector[Int, Int]")
   }
 

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerReplaceSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerReplaceSpec.scala
@@ -53,6 +53,31 @@ class MixerReplaceSpec extends FlatSpec with Matchers {
 
     Mixer[Source, Target].inject(target, source) shouldBe Source(7, "DANGER", List(a1, a2, a3), List(b1, b2))
   }
+
+  it should "not work for molecules where the smaller type has lost information" in {
+    case class A(i: Int, b: Boolean)
+    case class B(i: String)
+    case class Source(i: Int, s: String, as: List[A], bs: List[B])
+
+    case class BS(bs: List[B])
+    case class Target(i: Int, bs: BS, as: List[(Boolean)])
+
+    val a1 = A(1, true)
+    val a2 = A(2, false)
+    val a3 = A(3, true)
+
+    val b1 = B("ten")
+    val b2 = B("twenty")
+
+    val source = Source(17, "DANGER", List(A(0, false), A(0, true), A(0, false)), List(B("NOOO"), B("NOT MEEEEE")))
+    val target = Target(7, BS(List(b1, b2)), List(true, false, true))
+
+    // Note the internal molecule: Just uses source's value because the target doesn't have a molecule which can
+    // project onto it
+    // We have a Mixer[A, Boolean] but not the other way
+    Mixer[Source, Target].inject(target, source) shouldBe Source(7, "DANGER", source.as, List(b1, b2))
+  }
+
   it should "work when values are the same" in {
     case class Source(a: Int)
     case class Target(b: Int)

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/SelectFromAtomisedSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/SelectFromAtomisedSpec.scala
@@ -1,0 +1,99 @@
+package io.typechecked
+package alphabetsoup
+
+import org.scalatest._
+import shapeless.{::, HNil}
+import shapeless.test.illTyped
+
+// TODO: nested structure tests
+class SelectFromAtomisedSpec extends FlatSpec with Matchers {
+
+  "SelectFromAtomised" should "select an atomic value from an atomised structure" in {
+    type L = Int :: String :: HNil
+    type U = String
+
+    val l = 17 :: "twine" :: HNil
+
+    SelectFromAtomised[L, U].apply(l) shouldBe "twine"
+  }
+
+  it should "select a molecule from an atomised structure" in {
+    type L = Int :: List[String] :: HNil
+    type U = List[String]
+
+    val l = 17 :: List("twine", "yarn") :: HNil
+
+    SelectFromAtomised[L, U].apply(l) shouldBe List("twine", "yarn")
+  }
+
+  it should "fuzzily select a molecule from an atomised structure" in {
+    case class A(str: String)
+    case class B(str: String)
+
+    type L = Int :: List[A] :: HNil
+    type U = List[B]
+
+    val l = 17 :: List(A("twine"), A("yarn")) :: HNil
+
+    SelectFromAtomised[L, U].apply(l) shouldBe List(B("twine"), B("yarn"))
+  }
+
+  it should "replace an atomic value from an atomised structure" in {
+    type L = Int :: String :: HNil
+    type U = String
+
+    val l = 17 :: "twine" :: HNil
+
+    SelectFromAtomised[L, U].replace("thread", l) shouldBe 17 :: "thread" :: HNil
+  }
+
+  it should "replace a molecule from an atomised structure" in {
+    type L = Int :: List[String] :: HNil
+    type U = List[String]
+
+    val l = 17 :: List("twine", "yarn") :: HNil
+
+    SelectFromAtomised[L, U].replace(List("thread"), l) shouldBe 17 :: List("thread") :: HNil
+  }
+
+  it should "NOT fuzzily replace a molecule from an atomised structure" in {
+
+    // Fuzziness does NOT work with replacing molecules
+
+    case class A(str: String)
+    case class B(str: String)
+
+    type L = Int :: List[A] :: HNil
+    type U = List[B]
+
+    val l = 17 :: List(A("twine"), A("yarn")) :: HNil
+
+    SelectFromAtomised[L, U].replace(List(B("thread")), l) shouldBe l
+  }
+
+  it should "not compile for an atomic value from a non-atomised structure" in {
+    case class L(int: Int, str: String)
+    type U = String
+
+    illTyped("SelectFromAtomised[L, U]", ".*could not find implicit value.*SelectFromAtomised.*")
+  }
+
+  it should "not compile for a molecule from a non-atomised structure" in {
+    case class L(int: Int, str: List[String])
+    type U = List[String]
+
+    illTyped("SelectFromAtomised[L, U]", ".*could not find implicit value.*SelectFromAtomised.*")
+  }
+
+  it should "not compile for fuzzily selecting a molecule from a non-atomised structure" in {
+
+    case class A(str: String)
+    case class B(str: String)
+
+    case class L(int: Int, str: List[A])
+    type U = List[B]
+
+    illTyped("SelectFromAtomised[L, U]", ".*could not find implicit value.*SelectFromAtomised.*")
+  }
+
+}

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/SelectFromAtomisedSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/SelectFromAtomisedSpec.scala
@@ -56,9 +56,25 @@ class SelectFromAtomisedSpec extends FlatSpec with Matchers {
     SelectFromAtomised[L, U].replace(List("thread"), l) shouldBe 17 :: List("thread") :: HNil
   }
 
-  it should "NOT fuzzily replace a molecule from an atomised structure" in {
+  it should "NOT fuzzily replace a molecule from an atomised structure if the internal types cannot be mixed to one another" in {
 
     // Fuzziness does NOT work with replacing molecules
+
+    // A and B are not isomorphic; we have Mixer[A, B] but not Mixer[B, A]
+    case class A(str: String, int: Int)
+    case class B(str: String)
+
+    type L = Int :: List[A] :: HNil
+    type U = List[B]
+
+    val l = 17 :: List(A("twine", 0), A("yarn", 2)) :: HNil
+
+    SelectFromAtomised[L, U].replace(List(B("thread")), l) shouldBe l
+  }
+
+  it should "fuzzily replace a molecule from an atomised structure if the internal types are isomorphic" in {
+
+    // Fuzziness DOES work with replacing molecules if the internal types are isomorphic
 
     case class A(str: String)
     case class B(str: String)
@@ -68,7 +84,7 @@ class SelectFromAtomisedSpec extends FlatSpec with Matchers {
 
     val l = 17 :: List(A("twine"), A("yarn")) :: HNil
 
-    SelectFromAtomised[L, U].replace(List(B("thread")), l) shouldBe l
+    SelectFromAtomised[L, U].replace(List(B("thread")), l) shouldBe 17 :: List(A("thread")) :: HNil
   }
 
   it should "not compile for an atomic value from a non-atomised structure" in {

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/SelectFromAtomisedSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/SelectFromAtomisedSpec.scala
@@ -96,4 +96,20 @@ class SelectFromAtomisedSpec extends FlatSpec with Matchers {
     illTyped("SelectFromAtomised[L, U]", ".*could not find implicit value.*SelectFromAtomised.*")
   }
 
+  it should "not compile if the type is not present" in {
+    type L = Int :: String :: HNil
+    type U = Boolean
+
+    illTyped("SelectFromAtomised[L, U]", ".*could not find implicit value.*SelectFromAtomised.*")
+  }
+
+  it should "not compile if the type is not present even if there is a default present" in {
+    type L = Int :: String :: HNil
+    type U = Boolean
+
+    implicit val default: Atom.DefaultAtom[U] = Atom.DefaultAtom[U](false)
+
+    illTyped("SelectFromAtomised[L, U]", ".*could not find implicit value.*SelectFromAtomised.*")
+  }
+
 }

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/SelectOrDefaultSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/SelectOrDefaultSpec.scala
@@ -1,0 +1,64 @@
+package io.typechecked
+package alphabetsoup
+
+import org.scalatest._
+import shapeless.{::, HNil}
+import shapeless.test.illTyped
+
+import Atom.DefaultAtom
+
+// TODO: nested structure tests
+class SelectOrDefaultSpec extends FlatSpec with Matchers {
+
+  "SelectOrDefault" should "select a value from an atomised structure even with a default atom present" in {
+    type L = Int :: String :: HNil
+    type U = String
+
+    val l = 17 :: "twine" :: HNil
+
+    implicit val defaultU: DefaultAtom[U] = DefaultAtom[U]("default")
+
+    SelectOrDefault[L, U].apply(l) shouldBe "twine"
+  }
+
+  it should "replace a value in an atomised structure even with a default atom present" in {
+    type L = Int :: String :: HNil
+    type U = String
+
+    val l = 17 :: "twine" :: HNil
+
+    implicit val defaultU: DefaultAtom[U] = DefaultAtom[U]("default")
+
+    SelectOrDefault[L, U].replace("yarn", l) shouldBe 17 :: "yarn" :: HNil
+  }
+
+  it should "select a default from an atomised structure, if there is a default present but the type is not in the structure" in {
+    type L = Int :: String :: HNil
+    type U = Boolean
+
+    val l = 17 :: "twine" :: HNil
+
+    implicit val defaultU: DefaultAtom[U] = DefaultAtom[U](false)
+
+    SelectOrDefault[L, U].apply(l) shouldBe false
+  }
+
+  it should "replace nothing if there is a default present for a type not in the original structure" in {
+    type L = Int :: String :: HNil
+    type U = Boolean
+
+    val l = 17 :: "twine" :: HNil
+
+    implicit val defaultU: DefaultAtom[U] = DefaultAtom[U](false)
+
+    SelectOrDefault[L, U].replace(true, l) shouldBe l
+  }
+
+  it should "not compile if the type we want is not present and there is no default atom" in {
+    type L = Int :: String :: HNil
+    type U = Boolean
+
+    illTyped("SelectOrDefault[L, U]", ".*could not find implicit value.*SelectOrDefault.*")
+  }
+
+}


### PR DESCRIPTION
Implement atom replacement functionality throughout the typeclasses rather than top down to speed up compile times