### PR TITLE
Atomic type parameters

### DIFF
--- a/alphabet-soup-macros/src/main/scala/io/typechecked/alphabetsoup/macros/Atomic.scala
+++ b/alphabet-soup-macros/src/main/scala/io/typechecked/alphabetsoup/macros/Atomic.scala
@@ -2,8 +2,6 @@ package io.typechecked
 package alphabetsoup
 package macros
 
-import cats.data.NonEmptyList
-
 import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox._

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomMacroSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomMacroSpec.scala
@@ -170,15 +170,24 @@ class AtomMacroSpec extends FlatSpec with Matchers {
     class U extends T
     @Atomic class Foo[A <: T]
     implicitly[Atom[Foo[U]]]
-    assertDoesNotCompile("implicitly[Atom[Foo[S]]]")
+    illTyped(
+      "implicitly[Atom[Foo[S]]]",
+      "could not find implicit value for parameter.*"
+    )
 
     @Atomic class Bar[B >: T]
     implicitly[Atom[Bar[S]]]
-    assertDoesNotCompile("implicitly[Atom[Bar[U]]]")
+    illTyped(
+      "implicitly[Atom[Bar[U]]]",
+      "could not find implicit value for parameter.*"
+    )
 
     @Atomic class Faz[A >: U <: S]
     implicitly[Atom[Faz[T]]]
-    assertDoesNotCompile("implicitly[Atom[Faz[String]]]")
+    illTyped(
+      "implicitly[Atom[Faz[String]]]",
+      "could not find implicit value for parameter.*"
+    )
   }
 
 }

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomMacroSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomMacroSpec.scala
@@ -152,6 +152,35 @@ class AtomMacroSpec extends FlatSpec with Matchers {
    illTyped("@Atomic object Foo",".*Invalid: Can not annotate structure with @Atomic.*")
 
   }
+  it should "create an implicit Atom for a class with a type parameter" in {
+    @Atomic class Foo[A]
+    implicitly[Atom[Foo[String]]]
+  }
+  it should "create an implicit Atom for a class with a higher-kinded type parameter" in {
+    @Atomic class Foo[A[_]]
+    implicitly[Atom[Foo[Option]]]
+  }
+  it should "create an implicit Atom for a class with many type parameters" in {
+    @Atomic class Foo[A[_], B, C]
+    implicitly[Atom[Foo[Option, String, (Boolean, List[String])]]]
+  }
+  it should "create an implicit Atom for a class with a type parameter with a type bound" in {
+    trait S
+    class T extends S
+    class U extends T
+    @Atomic class Foo[A <: T]
+    implicitly[Atom[Foo[U]]]
+    assertDoesNotCompile("implicitly[Atom[Foo[S]]]")
+
+    @Atomic class Bar[B >: T]
+    implicitly[Atom[Bar[S]]]
+    assertDoesNotCompile("implicitly[Atom[Bar[U]]]")
+
+    @Atomic class Faz[A >: U <: S]
+    implicitly[Atom[Faz[T]]]
+    assertDoesNotCompile("implicitly[Atom[Faz[String]]]")
+  }
+
 }
 
 @Atomic protected sealed abstract class ProtectedFoo(implicit impl: DummyImplicit)


### PR DESCRIPTION
Allows the annotation `@Atomic` to be applied to classes and traits that take type parameters, including those that have type bounds. 