### PR TITLE
Mixer bug for non-primitives

### DIFF
--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
@@ -37,13 +37,22 @@ class MixerSpec extends FlatSpec with Matchers {
     Mixer[A1, A1].mix(A1(5, "hello")) shouldBe A1(5, "hello")
   }
 
-  it should "be gud" in {
+  it should "select smaller type from larger for non-primitives" in {
 
     @Atomic class A
     @Atomic class B
 
-    Mixer[(A, B), B]
+    pendingUntilFixed(illTyped("""Mixer[(A, B), B]"""))
 
+    @Atomic trait C
+    @Atomic trait D
+
+    implicitly[Mixer[(C, D), D]]
+
+    @Atomic case class E()
+    @Atomic case class F()
+
+    pendingUntilFixed(illTyped("""Mixer[(E, F), F]"""))
   }
 
   it should "not work on mis-matched simple types" in {

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
@@ -42,17 +42,22 @@ class MixerSpec extends FlatSpec with Matchers {
     @Atomic class A
     @Atomic class B
 
-    pendingUntilFixed(illTyped("""Mixer[(A, B), B]"""))
+    pendingUntilFixed{
+      "implicitly[Mixer[(A, B), B]]" should compile
+    }
 
     @Atomic trait C
     @Atomic trait D
 
     implicitly[Mixer[(C, D), D]]
+    implicitly[Mixer[(C, D), C]]
 
     @Atomic case class E()
     @Atomic case class F()
 
-    pendingUntilFixed(illTyped("""Mixer[(E, F), F]"""))
+    pendingUntilFixed{
+      "implicitly[Mixer[(E, F), F]]" should compile
+    }
   }
 
   it should "not work on mis-matched simple types" in {

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
@@ -37,10 +37,15 @@ class MixerSpec extends FlatSpec with Matchers {
     Mixer[A1, A1].mix(A1(5, "hello")) shouldBe A1(5, "hello")
   }
 
+  it should "select smaller type from larger for primitives" in {
+    implicitly[Mixer[(String, Int), Int]]
+    implicitly[Mixer[(String, Int), String]]
+  }
+
   it should "select smaller type from larger for non-primitives" in {
 
     @Atomic class A
-    @Atomic class B
+    @Atomic class Bgit
 
     pendingUntilFixed{
       "implicitly[Mixer[(A, B), B]]" should compile

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
@@ -45,7 +45,7 @@ class MixerSpec extends FlatSpec with Matchers {
   it should "select smaller type from larger for non-primitives" in {
 
     @Atomic class A
-    @Atomic class Bgit
+    @Atomic class B
 
     pendingUntilFixed{
       "implicitly[Mixer[(A, B), B]]" should compile

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/MixerSpec.scala
@@ -1,6 +1,7 @@
 package io.typechecked
 package alphabetsoup
 
+import io.typechecked.alphabetsoup.macros.Atomic
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import shapeless.::
@@ -34,6 +35,15 @@ class MixerSpec extends FlatSpec with Matchers {
     Mixer[String :: HNil, String :: HNil].mix("hello" :: HNil) shouldBe "hello" :: HNil
     Mixer[Tuple1[String], Tuple1[String]].mix(Tuple1("hello")) shouldBe Tuple1("hello")
     Mixer[A1, A1].mix(A1(5, "hello")) shouldBe A1(5, "hello")
+  }
+
+  it should "be gud" in {
+
+    @Atomic class A
+    @Atomic class B
+
+    Mixer[(A, B), B]
+
   }
 
   it should "not work on mis-matched simple types" in {


### PR DESCRIPTION
Selecting from a larger type fails when the types are non-primitive (except for `trait`s)