### PR TITLE
Molecule behaviour

### DIFF
--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Atom.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Atom.scala
@@ -17,27 +17,14 @@ object Atom {
   implicit val doubleAtom: Atom[Double] = new Atom[Double] {}
   implicit val longAtom: Atom[Long] = new Atom[Long] {}
 
-  private[typechecked] trait DefaultAtomImpl[T] {
-    def asDefaultAtom(value: T): DefaultAtom[T] = new DefaultAtom[T] {
-      def default: T = value
-    }
-  }
-
   sealed trait DefaultAtom[T] extends Atom[T] {
     def default: T
   }
 
   object DefaultAtom {
-    def apply[T](arg: T)(implicit impl: DefaultAtomImpl[T]): DefaultAtom[T] = impl.asDefaultAtom(arg)
-  }
-
-  object DefaultAtomImpl extends LowerPriorityDefaultAtomImpl {
-    implicit def forbidMoleculeAmbiguous1[T[_], A](implicit ev: Molecule[T, A]): DefaultAtomImpl[T[A]] = new DefaultAtomImpl[T[A]] {}
-    implicit def forbidMoleculeAmbiguous2[T[_], A](implicit ev: Molecule[T, A]): DefaultAtomImpl[T[A]] = new DefaultAtomImpl[T[A]] {}
-  }
-
-  trait LowerPriorityDefaultAtomImpl{
-    implicit def freeDefaultAtomImpl[T]: DefaultAtomImpl[T] = new DefaultAtomImpl[T] {}
+    def apply[T](arg: T): DefaultAtom[T] = new DefaultAtom[T] {
+      def default: T = arg
+    }
   }
 
   implicit val hnilAtom: DefaultAtom[HNil] = DefaultAtom.apply[HNil](HNil)

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Atomiser.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Atomiser.scala
@@ -1,9 +1,11 @@
 package io.typechecked
 package alphabetsoup
 
+import shapeless.::
+import shapeless.Generic
 import shapeless.HList
 import shapeless.Lazy
-import shapeless.{::, Generic}
+import shapeless.LowPriority
 
 // T => HList or Atom or Molecule
 trait Atomiser[T] extends Serializable {
@@ -36,17 +38,20 @@ object Atomiser extends LowPriorityAtomiserImplicits {
       def from(u: T): T = u
     }
 
-}
-
-trait LowPriorityAtomiserImplicits {
-
   // If we've hit a molecule we go no deeper
-  implicit def moleculeCase[M[_], T](implicit ev: Molecule[M, T]): Atomiser.Aux[M[T], M[T]] =
+  implicit def moleculeCase[M[_], T](
+    implicit ev: Molecule[M, T],
+    lp: LowPriority
+  ): Atomiser.Aux[M[T], M[T]] =
     new Atomiser[M[T]] {
       type Repr = M[T]
       def to(t: M[T]): M[T] = t
       def from(u: M[T]): M[T] = u
     }
+
+}
+
+trait LowPriorityAtomiserImplicits {
 
   // Turn T into an HList and recurse. Low priority because we should match on T being HList first
   implicit def genericCase[T, GenOut, AtomiserOut <: HList](

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Atomiser.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Atomiser.scala
@@ -12,7 +12,7 @@ trait Atomiser[T] extends Serializable {
   def from(r : Repr) : T
 }
 
-object Atomiser extends LowPriorityAtomiserImplicits1 {
+object Atomiser extends LowPriorityAtomiserImplicits {
 
   type Aux[T, Repr0] = Atomiser[T] { type Repr = Repr0 }
 
@@ -36,6 +36,10 @@ object Atomiser extends LowPriorityAtomiserImplicits1 {
       def from(u: T): T = u
     }
 
+}
+
+trait LowPriorityAtomiserImplicits {
+
   // If we've hit a molecule we go no deeper
   implicit def moleculeCase[M[_], T](implicit ev: Molecule[M, T]): Atomiser.Aux[M[T], M[T]] =
     new Atomiser[M[T]] {
@@ -43,10 +47,6 @@ object Atomiser extends LowPriorityAtomiserImplicits1 {
       def to(t: M[T]): M[T] = t
       def from(u: M[T]): M[T] = u
     }
-
-}
-
-trait LowPriorityAtomiserImplicits1 {
 
   // Turn T into an HList and recurse. Low priority because we should match on T being HList first
   implicit def genericCase[T, GenOut, AtomiserOut <: HList](

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Mixer.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/Mixer.scala
@@ -6,6 +6,7 @@ import shapeless.=:!=
 import shapeless.HList
 import shapeless.HNil
 import shapeless.Lazy
+import shapeless.LowPriority
 
 // This is the version application code should use
 trait Mixer[A, B] {
@@ -102,7 +103,8 @@ object MixerImpl {
   }
 
   implicit def bIsMoleculeRecurse[A, M[_], B](
-    implicit molecule: Molecule[M, B],
+    implicit lp: LowPriority,
+    molecule: Molecule[M, B],
     s: AtomSelector[A, M[B]]
   ): MixerImpl[A, M[B]] = new MixerImpl[A, M[B]] {
     def mix(a: A): M[B] = s(a)
@@ -148,7 +150,8 @@ object MixerImplFromAtomised extends LowPriorityMFAImplicits1 {
   }
 
   implicit def bHeadIsMoleculeRecurse[A, M[_], BH, BT <: HList](
-    implicit molecule: Molecule[M, BH],
+    implicit lp: LowPriority,
+    molecule: Molecule[M, BH],
     s: SelectOrDefaultOrTransmute[A, M[BH]],
     m2: MixerImplFromAtomised[A, BT]
   ): MixerImplFromAtomised[A, M[BH] :: BT] = new MixerImplFromAtomised[A, M[BH] :: BT] {

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/SelectFromAtomised.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/SelectFromAtomised.scala
@@ -68,6 +68,10 @@ object SelectFromAtomised extends LowPrioritySelectFromAtomised {
       def replace(u: U, l: H :: T): H :: T = st.value.replace(u, l.head) :: l.tail
     }
 
+}
+
+trait LowPrioritySelectFromAtomised extends LowLowPrioritySelectFromAtomised {
+
   // case where A & B are isomorphic
   implicit def fuzzyHeadSelectMoleculeABIso[M[_], A, T <: HList, B](
     implicit molecule: Molecule[M, B],
@@ -109,7 +113,7 @@ object SelectFromAtomised extends LowPrioritySelectFromAtomised {
 
 }
 
-trait LowPrioritySelectFromAtomised {
+trait LowLowPrioritySelectFromAtomised {
 
   implicit def fuzzyHeadSelectMolecule[M[_], A, T <: HList, B](
     implicit molecule: Molecule[M, B],

--- a/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/SelectTransmuted.scala
+++ b/alphabet-soup/src/main/scala/io/typechecked/alphabetsoup/SelectTransmuted.scala
@@ -13,14 +13,6 @@ object SelectTransmuted extends LowPrioritySelectAndTransmute {
       def apply(l: T :: L): U = transmute.convert(l.head)
     }
 
-  implicit def tryHeadMolecule[L <: HList, M[_], T, U](
-    implicit molecule: Molecule[M, T],
-    transmute: Transmute[M[T], U]
-  ): SelectTransmuted[M[T] :: L, U] =
-    new SelectTransmuted[M[T] :: L, U] {
-      override def apply(l: M[T] :: L): U = transmute.convert(l.head)
-    }
-
   implicit def recurseNested[L <: HList, T <: HList, U](implicit transmutation: SelectTransmuted[T, U]): SelectTransmuted[T :: L, U] =
     new SelectTransmuted[T :: L, U] {
       def apply(l: T :: L): U = transmutation(l.head)
@@ -28,6 +20,14 @@ object SelectTransmuted extends LowPrioritySelectAndTransmute {
 }
 
 trait LowPrioritySelectAndTransmute {
+
+  implicit def tryHeadMolecule[L <: HList, M[_], T, U](
+    implicit molecule: Molecule[M, T],
+    transmute: Transmute[M[T], U]
+  ): SelectTransmuted[M[T] :: L, U] =
+    new SelectTransmuted[M[T] :: L, U] {
+      override def apply(l: M[T] :: L): U = transmute.convert(l.head)
+    }
 
   implicit def recurseTail[L <: HList, T, U](implicit transmutation: SelectTransmuted[L, U]): SelectTransmuted[T :: L, U] =
     new SelectTransmuted[T :: L, U] {

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomiserSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomiserSpec.scala
@@ -276,14 +276,15 @@ class AtomiserSpec extends FlatSpec with Matchers {
   }
 
   it should "work with an atom and a molecule in scope" in {
-    implicit val mol : Molecule[List, String] = implicitly[Molecule[List, String]]
-    implicit val atom: Atom[List[String]] = Atom[List[String]]
+    import cats.implicits.catsStdInstancesForVector
+    implicit val mol : Molecule[Vector, String] = Molecule[Vector, String]
+    implicit val atom: Atom[Vector[String]] = Atom[Vector[String]]
 
-    case class A(value: List[String])
+    case class A(value: Vector[String])
 
     val gen = Atomiser[A]
 
-    (gen.to(A("hi" :: Nil)): List[String] :: HNil) shouldBe ("hi" :: Nil) :: HNil
+    (gen.to(A(Vector("hi"))): Vector[String] :: HNil) shouldBe Vector("hi") :: HNil
   }
 
   it should "atomise simple things correctly" in {

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomiserSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/AtomiserSpec.scala
@@ -275,6 +275,17 @@ class AtomiserSpec extends FlatSpec with Matchers {
     (gen.from(hlist): B) shouldBe value
   }
 
+  it should "work with an atom and a molecule in scope" in {
+    implicit val mol : Molecule[List, String] = implicitly[Molecule[List, String]]
+    implicit val atom: Atom[List[String]] = Atom[List[String]]
+
+    case class A(value: List[String])
+
+    val gen = Atomiser[A]
+
+    (gen.to(A("hi" :: Nil)): List[String] :: HNil) shouldBe ("hi" :: Nil) :: HNil
+  }
+
   it should "atomise simple things correctly" in {
 
     import macros.Atomic

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/DefaultAtomSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/DefaultAtomSpec.scala
@@ -75,7 +75,7 @@ class DefaultAtomSpec extends FlatSpec with Matchers {
 
   it should "be able to create default atom if a molecule exists" in {
     "implicitly[Molecule[List, String]]" should compile
-    "Atom.DefaultAtom[List[String]] = Atom.DefaultAtom(List.empty[String])" should compile
+    "val a: Atom.DefaultAtom[List[String]] = Atom.DefaultAtom(List.empty[String])" should compile
   }
 
   "Mixer" should "work with a supplied default" in {

--- a/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/DefaultAtomSpec.scala
+++ b/alphabet-soup/src/test/scala/io/typechecked/alphabetsoup/DefaultAtomSpec.scala
@@ -9,12 +9,6 @@ import shapeless.test.illTyped
 
 class DefaultAtomSpec extends FlatSpec with Matchers {
 
-  "DefaultAtom" should "not compile defaults for molecules" in {
-
-    illTyped("""Atom.DefaultAtom[List[String]](List("No!"))""")
-
-  }
-
   it should "not atom select when no default is supplied" in {
     case class A(a: Int)
     illTyped("AtomSelector[A, String].apply(A(7))")
@@ -77,6 +71,11 @@ class DefaultAtomSpec extends FlatSpec with Matchers {
       implicit val default: Atom.DefaultAtom[A] = Atom.DefaultAtom[A](new A{})
       "implicitly[Atom[A]]" should compile
     }
+  }
+
+  it should "be able to create default atom if a molecule exists" in {
+    "implicitly[Molecule[List, String]]" should compile
+    "Atom.DefaultAtom[List[String]] = Atom.DefaultAtom(List.empty[String])" should compile
   }
 
   "Mixer" should "work with a supplied default" in {


### PR DESCRIPTION
fixes https://github.com/TypeChecked/alphabet-soup/issues/37 by adding LowPriority implicits to molecule instances across the project. 
as a consequence default atoms can now be created for types that have a molecule instance. 

also see https://stackoverflow.com/questions/57933865/why-is-this-implicit-ambiguity-behaviour-happening